### PR TITLE
Relax the image comparison test threshold

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ def assert_page_snapshot(assert_snapshot) -> Callable[[Page, str], None]:
                 # There shouldn't be any animations, but disable for safety
                 animations="disabled",
             ),
-            threshold=0.3,
+            threshold=0.6,
         )
 
     return _assert_page_snapshot


### PR DESCRIPTION
OS updates have caused some very minor rendering differences between local and CI environments. Trying to further lock down the rendering stack would but a lot more complex, so just allow differences of a few more pixels.