### PR TITLE
Add tests for the lowest supported version of Allauth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ permissions:
 jobs:
   test-python:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        uv-resolution: [highest, lowest-direct]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -21,6 +24,8 @@ jobs:
         id: test-tox
         run: |
           uv run tox
+        env:
+          UV_RESOLUTION: ${{ matrix.uv-resolution }}
       - name: Persist test failure snapshots
         uses: actions/upload-artifact@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,9 @@ Repository = "https://github.com/kitware-resonant/django-auth-style"
 
 [project.optional-dependencies]
 allauth = [
-  # Required for "elements/details.html" template
-  "django-allauth>=65.8.0",
+  # 65.8.0 added "elements/details.html" template
+  # 65.9.0 fixed WebAuthn/MFA support, used by tests
+  "django-allauth>=65.9.0",
 ]
 oauth-toolkit = [
   "django-oauth-toolkit>=0",

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ type = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.2" },
-    { name = "django-allauth", marker = "extra == 'allauth'", specifier = ">=65.8.0" },
+    { name = "django-allauth", marker = "extra == 'allauth'", specifier = ">=65.9.0" },
     { name = "django-oauth-toolkit", marker = "extra == 'oauth-toolkit'", specifier = ">=0" },
 ]
 provides-extras = ["allauth", "oauth-toolkit"]


### PR DESCRIPTION
Require `django-allauth` 65.9.0.